### PR TITLE
[ORG-27] Get by id endpoint

### DIFF
--- a/organizator_api/app/users/domain/exceptions.py
+++ b/organizator_api/app/users/domain/exceptions.py
@@ -1,2 +1,6 @@
 class UserAlreadyExists(Exception):
     pass
+
+
+class UserNotFound(Exception):
+    pass

--- a/organizator_api/app/users/domain/repositories.py
+++ b/organizator_api/app/users/domain/repositories.py
@@ -1,3 +1,4 @@
+import uuid
 from abc import ABC, abstractmethod
 from typing import List
 
@@ -11,4 +12,8 @@ class UserRepository(ABC):
 
     @abstractmethod
     def get_all(self) -> List[User]:
+        pass
+
+    @abstractmethod
+    def get_by_id(self, user_id: uuid.UUID) -> User:
         pass

--- a/organizator_api/app/users/domain/use_cases/get_by_id_use_case.py
+++ b/organizator_api/app/users/domain/use_cases/get_by_id_use_case.py
@@ -1,0 +1,12 @@
+import uuid
+
+from app.users.infrastructure.repository_factories import UserRepositoryFactory
+from app.users.domain.models.user import User
+
+
+class GetByIdUseCase:
+    def __init__(self) -> None:
+        self.user_repository = UserRepositoryFactory.create()
+
+    def execute(self, user_id: uuid.UUID) -> User:
+        return self.user_repository.get_by_id(user_id=user_id)

--- a/organizator_api/app/users/domain/use_cases/get_by_id_use_case.py
+++ b/organizator_api/app/users/domain/use_cases/get_by_id_use_case.py
@@ -4,7 +4,7 @@ from app.users.infrastructure.repository_factories import UserRepositoryFactory
 from app.users.domain.models.user import User
 
 
-class GetByIdUseCase:
+class GetUserByIdUseCase:
     def __init__(self) -> None:
         self.user_repository = UserRepositoryFactory.create()
 

--- a/organizator_api/app/users/infrastructure/http/urls.py
+++ b/organizator_api/app/users/infrastructure/http/urls.py
@@ -1,8 +1,13 @@
 from django.urls import path
 
-from app.users.infrastructure.http.views import create_new_user, get_all_users
+from app.users.infrastructure.http.views import (
+    create_new_user,
+    get_all_users,
+    get_user_by_id,
+)
 
 urlpatterns = [
     path("new", create_new_user),
     path("", get_all_users),
+    path("<uuid:user_id>", get_user_by_id),
 ]

--- a/organizator_api/app/users/infrastructure/http/views.py
+++ b/organizator_api/app/users/infrastructure/http/views.py
@@ -1,13 +1,15 @@
 import json
+import uuid
 
 from django.http import HttpRequest, HttpResponse
 from django.views.decorators.http import require_http_methods
 
 from app.users.application.requests import CreateUserRequest
 from app.users.domain.use_cases.create_user_use_case import CreateUserUseCase
-from app.users.domain.exceptions import UserAlreadyExists
+from app.users.domain.exceptions import UserAlreadyExists, UserNotFound
 from app.users.domain.use_cases.get_all_users_use_case import GetAllUsersUseCase
 from app.users.application.response import UserResponse
+from app.users.domain.use_cases.get_by_id_use_case import GetUserByIdUseCase
 
 
 @require_http_methods(["POST"])
@@ -53,4 +55,18 @@ def get_all_users(request: HttpRequest) -> HttpResponse:
 
     return HttpResponse(
         status=200, content=json.dumps(users_response), content_type="application/json"
+    )
+
+
+@require_http_methods(["GET"])
+def get_user_by_id(request: HttpRequest, user_id: uuid.UUID) -> HttpResponse:
+    try:
+        user = GetUserByIdUseCase().execute(user_id=user_id)
+    except UserNotFound:
+        return HttpResponse(status=404, content="User does not exist")
+
+    return HttpResponse(
+        status=200,
+        content=json.dumps(UserResponse.from_user(user).to_dict()),
+        content_type="application/json",
     )

--- a/organizator_api/app/users/infrastructure/persistance/orm_user_repository.py
+++ b/organizator_api/app/users/infrastructure/persistance/orm_user_repository.py
@@ -1,9 +1,11 @@
+import uuid
+
 from django.db import IntegrityError
 from typing import List
 
 from app.users.domain.models.user import User
 from app.users.domain.repositories import UserRepository
-from app.users.domain.exceptions import UserAlreadyExists
+from app.users.domain.exceptions import UserAlreadyExists, UserNotFound
 from app.users.infrastructure.persistance.models.orm_user import ORMUser
 
 
@@ -16,6 +18,13 @@ class ORMUserRepository(UserRepository):
 
     def get_all(self) -> List[User]:
         return [self._to_domain(user) for user in ORMUser.objects.all()]
+
+    def get_by_id(self, user_id: uuid.UUID) -> User:
+        try:
+            user = self._to_domain(ORMUser.objects.get(id=user_id))
+            return user
+        except ORMUser.DoesNotExist:
+            raise UserNotFound()
 
     def _to_model(self, user: User) -> ORMUser:
         return ORMUser(

--- a/organizator_api/tests/users/domain/usecases/test_get_user_by_id_use_case.py
+++ b/organizator_api/tests/users/domain/usecases/test_get_user_by_id_use_case.py
@@ -1,7 +1,7 @@
 from tests.api_tests import ApiTests
 from tests.users.domain.UserFactory import UserFactory
 
-from app.users.domain.use_cases.get_by_id_use_case import GetByIdUseCase
+from app.users.domain.use_cases.get_by_id_use_case import GetUserByIdUseCase
 
 
 class TestGetUserByIdUseCase(ApiTests):
@@ -15,7 +15,7 @@ class TestGetUserByIdUseCase(ApiTests):
         self.user_repository.create(user)
 
         # When
-        user = GetByIdUseCase().execute(user_id=user.id)
+        user = GetUserByIdUseCase().execute(user_id=user.id)
 
         # Then
         self.assertEqual(len(self.user_repository.get_all()), 1)

--- a/organizator_api/tests/users/domain/usecases/test_get_user_by_id_use_case.py
+++ b/organizator_api/tests/users/domain/usecases/test_get_user_by_id_use_case.py
@@ -1,0 +1,30 @@
+from tests.api_tests import ApiTests
+from tests.users.domain.UserFactory import UserFactory
+
+from app.users.domain.use_cases.get_by_id_use_case import GetByIdUseCase
+
+
+class TestGetUserByIdUseCase(ApiTests):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user_repository.clear()
+
+    def test__given_user_id__when_get_user_by_id__then_user_is_returned(self) -> None:
+        # Given
+        user = UserFactory().create()
+        self.user_repository.create(user)
+
+        # When
+        user = GetByIdUseCase().execute(user_id=user.id)
+
+        # Then
+        self.assertEqual(len(self.user_repository.get_all()), 1)
+        self.assertEqual(user.id, user.id)
+        self.assertEqual(user.email, user.email)
+        self.assertEqual(user.password, user.password)
+        self.assertEqual(user.first_name, user.first_name)
+        self.assertEqual(user.last_name, user.last_name)
+        self.assertEqual(user.username, user.username)
+        self.assertEqual(user.bio, user.bio)
+        self.assertEqual(user.profile_image, user.profile_image)
+        self.assertEqual(user.created_at, user.created_at)

--- a/organizator_api/tests/users/infrastructure/http/test_views.py
+++ b/organizator_api/tests/users/infrastructure/http/test_views.py
@@ -133,3 +133,32 @@ class TestUserViews(ApiTests):
             response.content,
             b'[{"id": "ef6f6fb3-ba12-43dd-a0da-95de8125b1cc", "username": "carlotacb", "email": "carlota@hackupc.com", "first_name": "Carlota", "last_name": "Catot", "bio": "The user that is using this application", "profile_image": "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png"}, {"id": "be0f4c18-4a7c-4c1e-8a62-fc50916b6c88", "username": "carkbra", "email": "carkbra@gmail.com", "first_name": "Carlota", "last_name": "Catot", "bio": "The user that is using this application", "profile_image": "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png"}]',
         )
+
+    def test__given_user_in_db__when_get_by_id__then_user_is_returned(self) -> None:
+        # Given
+        user = UserFactory().create()
+        self.user_repository.create(user)
+
+        # When
+        response = self.client.get(
+            "/organizator-api/users/ef6f6fb3-ba12-43dd-a0da-95de8125b1cc"
+        )
+
+        # Then
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.content,
+            b'{"id": "ef6f6fb3-ba12-43dd-a0da-95de8125b1cc", "username": "carlotacb", "email": "carlota@hackupc.com", "first_name": "Carlota", "last_name": "Catot", "bio": "The user that is using this application", "profile_image": "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png"}',
+        )
+
+    def test__given_non_existing_user_in_db__when_get_by_id__then_not_found_is_returned(
+        self,
+    ) -> None:
+        # When
+        response = self.client.get(
+            "/organizator-api/users/ef6f6fb3-ba12-43dd-a0da-95de8125b1cd"
+        )
+
+        # Then
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.content, b"User does not exist")

--- a/organizator_api/tests/users/infrastructure/persistance/test_orm_user_repository.py
+++ b/organizator_api/tests/users/infrastructure/persistance/test_orm_user_repository.py
@@ -6,7 +6,7 @@ from tests.users.domain.UserFactory import UserFactory
 
 from app.users.infrastructure.persistance.orm_user_repository import ORMUserRepository
 from app.users.infrastructure.persistance.models.orm_user import ORMUser
-from app.users.domain.exceptions import UserAlreadyExists
+from app.users.domain.exceptions import UserAlreadyExists, UserNotFound
 
 
 class TestORMUserRepository(ApiTests):
@@ -76,3 +76,38 @@ class TestORMUserRepository(ApiTests):
         self.assertEqual(users[1].username, user2.username)
         self.assertEqual(users[1].bio, user2.bio)
         self.assertEqual(users[1].profile_image, user2.profile_image)
+
+    def test__given_a_user__when_get_by_id__then_user_is_returned(self) -> None:
+        # Given
+        user = UserFactory().create()
+        ORMUserRepository().create(user=user)
+
+        # When
+        user = ORMUserRepository().get_by_id(user.id)
+
+        # Then
+        self.assertEqual(user.id, user.id)
+        self.assertEqual(type(user.id), uuid.UUID)
+        self.assertEqual(user.email, user.email)
+        self.assertEqual(type(user.email), str)
+        self.assertEqual(user.password, user.password)
+        self.assertEqual(type(user.password), str)
+        self.assertEqual(user.first_name, user.first_name)
+        self.assertEqual(type(user.first_name), str)
+        self.assertEqual(user.last_name, user.last_name)
+        self.assertEqual(type(user.last_name), str)
+        self.assertEqual(user.username, user.username)
+        self.assertEqual(type(user.username), str)
+        self.assertEqual(user.bio, user.bio)
+        self.assertEqual(type(user.bio), str)
+        self.assertEqual(user.profile_image, user.profile_image)
+        self.assertEqual(type(user.profile_image), str)
+        self.assertEqual(type(user.created_at), datetime)
+        self.assertEqual(type(user.updated_at), datetime)
+
+    def test__given_a_non_existing_id__when_get_by_id__then_user_not_found_is_raised(
+        self,
+    ) -> None:
+        # Then
+        with self.assertRaises(UserNotFound):
+            ORMUserRepository().get_by_id(uuid.uuid4())

--- a/organizator_api/tests/users/mocks/user_repository_mock.py
+++ b/organizator_api/tests/users/mocks/user_repository_mock.py
@@ -1,8 +1,9 @@
+import uuid
 from typing import List
 
 from app.users.domain.repositories import UserRepository
 from app.users.domain.models.user import User
-from app.users.domain.exceptions import UserAlreadyExists
+from app.users.domain.exceptions import UserAlreadyExists, UserNotFound
 
 
 class UserRepositoryMock(UserRepository):
@@ -17,6 +18,12 @@ class UserRepositoryMock(UserRepository):
 
     def get_all(self) -> List[User]:
         return self.users
+
+    def get_by_id(self, user_id: uuid.UUID) -> User:
+        for user in self.users:
+            if user.id == user_id:
+                return user
+        raise UserNotFound()
 
     def clear(self) -> None:
         self.users = []


### PR DESCRIPTION
Get all users endpoint is created with the path: `GET /organizator-api/users/a81978f8-1d4d-48a2-b49f-7b270e9c2393`

Expected response example

```
{
    "id": "a81978f8-1d4d-48a2-b49f-7b270e9c2393",
    "username": "carlota",
    "email": "carlota@hackpc.com",
    "first_name": "Carlota",
    "last_name": "Catot",
    "bio": "I'm Carlota",
    "profile_image": "https://www.google.com"
}
```
