### PR TITLE
[ORG-26] Update user endpoint

### DIFF
--- a/organizator_api/app/users/application/requests.py
+++ b/organizator_api/app/users/application/requests.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -10,3 +11,12 @@ class CreateUserRequest:
     username: str
     bio: str
     profile_image: str
+
+
+@dataclass
+class UpdateUserRequest:
+    username: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    bio: Optional[str] = None
+    profile_image: Optional[str] = None

--- a/organizator_api/app/users/domain/repositories.py
+++ b/organizator_api/app/users/domain/repositories.py
@@ -21,3 +21,7 @@ class UserRepository(ABC):
     @abstractmethod
     def get_by_username(self, username: str) -> User:
         pass
+
+    @abstractmethod
+    def update(self, user: User) -> None:
+        pass

--- a/organizator_api/app/users/domain/use_cases/update_user_use_case.py
+++ b/organizator_api/app/users/domain/use_cases/update_user_use_case.py
@@ -1,0 +1,31 @@
+import uuid
+from datetime import datetime, timezone
+
+from app.users.infrastructure.repository_factories import UserRepositoryFactory
+from app.users.application.requests import UpdateUserRequest
+from app.users.domain.models.user import User
+
+
+class UpdateUserUseCase:
+    def __init__(self) -> None:
+        self.user_repository = UserRepositoryFactory.create()
+
+    def execute(self, user_id: uuid.UUID, user: UpdateUserRequest) -> User:
+        original_user = self.user_repository.get_by_id(user_id)
+        new_user = User(
+            id=user_id,
+            email=original_user.email,
+            password=original_user.password,
+            username=user.username if user.username else original_user.username,
+            profile_image=user.profile_image
+            if user.profile_image
+            else original_user.profile_image,
+            first_name=user.first_name if user.first_name else original_user.first_name,
+            last_name=user.last_name if user.last_name else original_user.last_name,
+            bio=user.bio if user.bio else original_user.bio,
+            created_at=original_user.created_at,
+            updated_at=datetime.now(tz=timezone.utc),
+        )
+
+        self.user_repository.update(new_user)
+        return new_user

--- a/organizator_api/app/users/infrastructure/persistance/orm_user_repository.py
+++ b/organizator_api/app/users/infrastructure/persistance/orm_user_repository.py
@@ -33,6 +33,23 @@ class ORMUserRepository(UserRepository):
         except ORMUser.DoesNotExist:
             raise UserNotFound()
 
+    def update(self, user: User) -> None:
+        try:
+            orm_user = ORMUser.objects.get(id=user.id)
+            orm_user.email = user.email
+            orm_user.password = user.password
+            orm_user.first_name = user.first_name
+            orm_user.last_name = user.last_name
+            orm_user.username = user.username
+            orm_user.bio = user.bio
+            orm_user.profile_image = user.profile_image
+            orm_user.updated_at = user.updated_at
+            orm_user.save()
+        except ORMUser.DoesNotExist:
+            raise UserNotFound()
+        except IntegrityError:
+            raise UserAlreadyExists()
+
     def _to_model(self, user: User) -> ORMUser:
         return ORMUser(
             id=user.id,

--- a/organizator_api/app/users/infrastructure/persistance/orm_user_repository.py
+++ b/organizator_api/app/users/infrastructure/persistance/orm_user_repository.py
@@ -36,8 +36,6 @@ class ORMUserRepository(UserRepository):
     def update(self, user: User) -> None:
         try:
             orm_user = ORMUser.objects.get(id=user.id)
-            orm_user.email = user.email
-            orm_user.password = user.password
             orm_user.first_name = user.first_name
             orm_user.last_name = user.last_name
             orm_user.username = user.username

--- a/organizator_api/tests/users/domain/usecases/test_update_user_use_case.py
+++ b/organizator_api/tests/users/domain/usecases/test_update_user_use_case.py
@@ -1,0 +1,91 @@
+import uuid
+
+from app.users.application.requests import UpdateUserRequest
+from app.users.domain.use_cases.update_user_use_case import UpdateUserUseCase
+from tests.api_tests import ApiTests
+from tests.users.domain.UserFactory import UserFactory
+
+
+class TestUpdateUserUseCase(ApiTests):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user_repository.clear()
+        user = UserFactory().create()
+        self.user_repository.create(user)
+
+    def test__given_update_user_request__when_update_user__then_the_user_is_updated(
+        self,
+    ) -> None:
+        # Given
+        user_data = UpdateUserRequest(
+            username="carlota",
+            first_name="Carlota",
+            last_name="Catot",
+            bio="I'm a cat",
+            profile_image="https://www.hacknights.dev/images/hacknight.png",
+        )
+
+        # When
+        user = UpdateUserUseCase().execute(
+            user_id=uuid.UUID("ef6f6fb3-ba12-43dd-a0da-95de8125b1cc"), user=user_data
+        )
+
+        # Then
+        self.assertEqual("carlota", user.username)
+        self.assertEqual("Carlota", user.first_name)
+        self.assertEqual("Catot", user.last_name)
+        self.assertEqual("I'm a cat", user.bio)
+        self.assertEqual(
+            "https://www.hacknights.dev/images/hacknight.png", user.profile_image
+        )
+        self.assertEqual("carlota@hackupc.com", user.email)
+
+    def test__given_update_user_request_with_empty_fields__when_update_user__then_the_user_is_not_updated(
+        self,
+    ) -> None:
+        # Given
+        user_data = UpdateUserRequest(
+            username="",
+            first_name="",
+            last_name="",
+            bio="",
+            profile_image="",
+        )
+
+        # When
+        user = UpdateUserUseCase().execute(
+            user_id=uuid.UUID("ef6f6fb3-ba12-43dd-a0da-95de8125b1cc"), user=user_data
+        )
+
+        # Then
+        self.assertEqual("carlotacb", user.username)
+        self.assertEqual("Carlota", user.first_name)
+        self.assertEqual("Catot", user.last_name)
+        self.assertEqual("The user that is using this application", user.bio)
+        self.assertEqual(
+            "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png",
+            user.profile_image,
+        )
+
+    def test__given_update_user_request_with_only_bio__when_update_user__then_the_user_is_updated(
+        self,
+    ) -> None:
+        # Given
+        user_data = UpdateUserRequest(
+            bio="I'm the beeest",
+        )
+
+        # When
+        user = UpdateUserUseCase().execute(
+            user_id=uuid.UUID("ef6f6fb3-ba12-43dd-a0da-95de8125b1cc"), user=user_data
+        )
+
+        # Then
+        self.assertEqual("carlotacb", user.username)
+        self.assertEqual("Carlota", user.first_name)
+        self.assertEqual("Catot", user.last_name)
+        self.assertEqual("I'm the beeest", user.bio)
+        self.assertEqual(
+            "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png",
+            user.profile_image,
+        )

--- a/organizator_api/tests/users/infrastructure/persistance/test_orm_user_repository.py
+++ b/organizator_api/tests/users/infrastructure/persistance/test_orm_user_repository.py
@@ -136,3 +136,49 @@ class TestORMUserRepository(ApiTests):
         # Then
         with self.assertRaises(UserNotFound):
             ORMUserRepository().get_by_username("non_existing_username")
+
+    def test__given_a_user__when_update__then_user_is_updated(self) -> None:
+        # Given
+        user = UserFactory().create()
+        ORMUserRepository().create(user=user)
+
+        # When
+        user.bio = "My name is Carlota and I love all the events I am going to"
+        ORMUserRepository().update(user=user)
+
+        # Then
+        user = ORMUserRepository().get_by_id(user.id)
+        self.assertEqual(
+            user.bio, "My name is Carlota and I love all the events I am going to"
+        )
+        self.assertEqual(type(user.bio), str)
+
+    def test__given_a_non_existing_user__when_update__then_user_not_found_is_raised(
+        self,
+    ) -> None:
+        # Given
+        user = UserFactory().create()
+
+        # Then
+        with self.assertRaises(UserNotFound):
+            ORMUserRepository().update(user=user)
+
+    def test__given_a_user__when_update_with_a_username_that_already_exists__then_user_is_updated(
+        self,
+    ) -> None:
+        # Given
+        user = UserFactory().create()
+        ORMUserRepository().create(user=user)
+        user2 = UserFactory().create(
+            new_id=uuid.UUID("be0f4c18-4a7c-4c1e-8a62-fc50916b6c88"),
+            email="carkbra@gmail.com",
+            username="carlota2",
+        )
+        ORMUserRepository().create(user=user2)
+
+        # When
+        user2.username = "carlotacb"
+
+        # Then
+        with self.assertRaises(UserAlreadyExists):
+            ORMUserRepository().update(user=user2)

--- a/organizator_api/tests/users/mocks/user_repository_mock.py
+++ b/organizator_api/tests/users/mocks/user_repository_mock.py
@@ -39,8 +39,6 @@ class UserRepositoryMock(UserRepository):
                 raise UserAlreadyExists()
         for u in self.users:
             if user.id == u.id:
-                u.email = user.email
-                u.password = user.password
                 u.first_name = user.first_name
                 u.last_name = user.last_name
                 u.username = user.username

--- a/organizator_api/tests/users/mocks/user_repository_mock.py
+++ b/organizator_api/tests/users/mocks/user_repository_mock.py
@@ -31,5 +31,24 @@ class UserRepositoryMock(UserRepository):
                 return user
         raise UserNotFound()
 
+    def update(self, user: User) -> None:
+        for u in self.users:
+            if (
+                u.username == user.username or u.email == user.email
+            ) and user.id != u.id:
+                raise UserAlreadyExists()
+        for u in self.users:
+            if user.id == u.id:
+                u.email = user.email
+                u.password = user.password
+                u.first_name = user.first_name
+                u.last_name = user.last_name
+                u.username = user.username
+                u.bio = user.bio
+                u.profile_image = user.profile_image
+                u.updated_at = user.updated_at
+                return
+        raise UserNotFound()
+
     def clear(self) -> None:
         self.users = []


### PR DESCRIPTION
Get all users endpoint is created with the path: `POST /organizator-api/users/update/d949490a-ac5b-4906-b408-56d9f0661b7f`

Expected body

```
{
    "username": "carlota",
    "first_name": "Carlota",
    "last_name": "Catot",
    "bio": "I'm Carlota",
    "profile_image": "https://www.google.com"
}
```